### PR TITLE
feat(api): Simplify api and SDK setup.

### DIFF
--- a/Example/LiveExampleAppUIKit/LiveExampleAppUIKit/AppDelegate.swift
+++ b/Example/LiveExampleAppUIKit/LiveExampleAppUIKit/AppDelegate.swift
@@ -6,12 +6,19 @@
 //
 
 import UIKit
+import Live // 1) Import Live
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
 	var window: UIWindow?
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+		// 2) Setup SDK with your domain & API Key
+		LiveSDK.initialize(
+			withDomain: "api.pbj-live.dev.pbj.engineering",
+			apiKey: "pk_OllxJqe45s4ofRuTP3yHADCBNraEyXjcds1ZufBiOCwoKjrkkt1ecpBuKNNSxfvREBKROefKOBq3aCkbLUviVv7T24vFQGxuA6kX9vpwMuqBfX7sviF8ZA5c72dw3wzeFRKnoY9nzwGCOLyoJlR")
+
 		window = UIWindow(frame: UIScreen.main.bounds)
 		window?.rootViewController = UINavigationController(rootViewController: ViewController())
 		window?.makeKeyAndVisible()

--- a/Example/LiveExampleAppUIKit/LiveExampleAppUIKit/ViewController.swift
+++ b/Example/LiveExampleAppUIKit/LiveExampleAppUIKit/ViewController.swift
@@ -30,10 +30,8 @@ class ViewController: UIViewController {
 
 	@objc
 	func buttonTapped() {
-		// 2) Create a LivePlayerViewController with your credentials
-		let livePlayerVC = LivePlayerViewController(domain: "api.pbj-live.dev.pbj.engineering",
-																								apiKey: "pk_OllxJqe45s4ofRuTP3yHADCBNraEyXjcds1ZufBiOCwoKjrkkt1ecpBuKNNSxfvREBKROe" +
-																									"fKOBq3aCkbLUviVv7T24vFQGxuA6kX9vpwMuqBfX7sviF8ZA5c72dw3wzeFRKnoY9nzwGCOLyoJlR", liveStreamId: "0418ea46-c157-4b2c-8fa8-b002857dfdc8")
+		// 3) Create a LivePlayerViewController
+		let livePlayerVC = LivePlayerViewController() // Optionally pass in a LivestreamId to target a specific show.
 		livePlayerVC.delegate = self
 		present(livePlayerVC, animated: true, completion: nil)
 	}

--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ Stream your PBJ.live content from your iOS App.
 https://github.com/pbj-apps/Live-ios-sdk
 ```
 
-## 2. Import Live at the top of your file
+## 2. Initialize the LivePlayerSDK with your credentials on App start
+A good place to do this is typically the `AppDelegate`.
 ```swift
 import Live
+
+// [...]
+
+LiveSDK.initialize(withDomain: "YOUR_DOMAIN", apiKey: "YOUR_API_KEY")
 ```
 
-## 3. Create a LivePlayerViewController with your credentials 
+## 3. Create a LivePlayerViewController
 ```swift
-let livePlayerVC = LivePlayerViewController(
-    domain: "YOUR_DOMAIN",
-    apiKey: "YOUR_API_KEY",
-    liveStreamId: "OPTIONAL_LIVESTREAM_ID")
+let livePlayerVC = LivePlayerViewController() // Optionally pass a liveStreamId.
 livePlayerVC.delegate = self
 ```
 

--- a/Sources/Live/LivePlayer/LivePlayerViewController.swift
+++ b/Sources/Live/LivePlayer/LivePlayerViewController.swift
@@ -9,6 +9,18 @@ import SwiftUI
 import Combine
 import AVKit
 
+public class LiveSDK {
+
+	static let shared = LiveSDK()
+	var domain: String = ""
+	var apiKey: String = ""
+
+	public static func initialize(withDomain: String, apiKey: String) {
+		shared.domain = withDomain
+		shared.apiKey = apiKey
+	}
+}
+
 public protocol LivePlayerViewControllerDelegate {
 	func livePlayerViewControllerDidTapClose()
 }
@@ -25,9 +37,20 @@ public class LivePlayerViewController: UIViewController, ObservableObject {
 		view = LivePlayerViewControllerView()
 	}
 
-	public convenience init(domain: String, apiKey: String, liveStreamId: String?) {
+	public convenience init() {
+		self.init(nibName: nil, bundle: nil)
+		setup()
+	}
+
+	public convenience init(liveStreamId: String) {
 		self.init(nibName: nil, bundle: nil)
 		self.liveStreamId = liveStreamId
+		setup()
+	}
+
+	private func setup() {
+		let domain = LiveSDK.shared.domain
+		let apiKey = LiveSDK.shared.apiKey
 		self.api = RestApi(apiUrl: "https://\(domain)/api", webSocketsUrl: "wss://\(domain)/ws", apiKey: apiKey)
 		// At the moment, an authenticated user is needed to get a Livestream.
 		// TODO Remove and replace by the correct authentication method.


### PR DESCRIPTION
Simplify api and SDK setup + Update Readme.
Initialization is now done separately in `AppDelegate`, thus enabling having multiple `LivePlayerViewController` connected to different livestreams.

```swift
LiveSDK.initialize(withDomain: "YOUR_DOMAIN", apiKey: "YOUR_API_KEY")
```

```swift
let livePlayerVC = LivePlayerViewController() // Optionally pass a liveStreamId.
```

As discussed with @glemmaPaul 