### PR TITLE
Guest auth

### DIFF
--- a/Sources/Live/Core/ConcreteImplementation/LiveStream/RestApi+LiveStream.swift
+++ b/Sources/Live/Core/ConcreteImplementation/LiveStream/RestApi+LiveStream.swift
@@ -22,6 +22,12 @@ extension RestApi: LiveStreamRepository {
 			return page.results.map { $0.toLiveStream() }
 		}.eraseToAnyPublisher()
 	}
+	
+	public func getCurrentLiveStreams() -> AnyPublisher<[LiveStream], Error> {
+		return get("/episodes/current").map { (page: JSONPage<JSONLiveStream>) in
+			return page.results.map { $0.toLiveStream() }
+		}.eraseToAnyPublisher()
+	}
 
 	public func getLiveStreamsSchedule() -> AnyPublisher<[LiveStream], Error> {
 		let paginator = RestApiPaginator<JSONLiveStream, LiveStream>(baseUrl: baseUrl, "/live-streams/schedule?days_ahead=7", client: network, mapping: { $0.toLiveStream() })

--- a/Sources/Live/Core/ConcreteImplementation/LiveStream/RestApi+LiveStream.swift
+++ b/Sources/Live/Core/ConcreteImplementation/LiveStream/RestApi+LiveStream.swift
@@ -28,6 +28,12 @@ extension RestApi: LiveStreamRepository {
 			return page.results.map { $0.toLiveStream() }
 		}.eraseToAnyPublisher()
 	}
+	
+	public func getCurrentLiveStream() -> AnyPublisher<LiveStream?, Error> {
+		return getCurrentLiveStreams().map { livestreams -> LiveStream? in
+			return livestreams.first
+		}.eraseToAnyPublisher()
+	}
 
 	public func fetchLiveStream(liveStreamId: String) -> AnyPublisher<LiveStream, Error> {
 		return get("/live-streams/\(liveStreamId)").map { (jsonLiveStream: JSONLiveStream) in

--- a/Sources/Live/Core/ConcreteImplementation/LiveStream/RestApi+LiveStream.swift
+++ b/Sources/Live/Core/ConcreteImplementation/LiveStream/RestApi+LiveStream.swift
@@ -29,6 +29,12 @@ extension RestApi: LiveStreamRepository {
 		}.eraseToAnyPublisher()
 	}
 
+	public func fetchLiveStream(liveStreamId: String) -> AnyPublisher<LiveStream, Error> {
+		return get("/live-streams/\(liveStreamId)").map { (jsonLiveStream: JSONLiveStream) in
+			return jsonLiveStream.toLiveStream()
+		}.eraseToAnyPublisher()
+	}
+
 	public func getLiveStreamsSchedule() -> AnyPublisher<[LiveStream], Error> {
 		let paginator = RestApiPaginator<JSONLiveStream, LiveStream>(baseUrl: baseUrl, "/live-streams/schedule?days_ahead=7", client: network, mapping: { $0.toLiveStream() })
 		return paginator.fetchAllPages()

--- a/Sources/Live/Core/ConcreteImplementation/RestApi+Guest.swift
+++ b/Sources/Live/Core/ConcreteImplementation/RestApi+Guest.swift
@@ -1,0 +1,28 @@
+//
+//  RestApi+Guest.swift
+//  
+//
+//  Created by Sacha DSO on 14/01/2021.
+//
+
+import Foundation
+import Combine
+import Networking
+
+extension RestApi {
+	
+	func authenticateAsGuest() -> AnyPublisher<(), Error> {
+		return fetchGuestToken().map { [weak self] r in
+			self?.authenticationToken = r.auth_token
+		}.eraseToAnyPublisher()
+	}
+	
+	func fetchGuestToken() -> AnyPublisher<JSONGuestAuthResponse, Error> {
+		post("/auth/guest/session")
+	}
+}
+
+
+struct JSONGuestAuthResponse: Decodable, NetworkingJSONDecodable {
+	let auth_token: String
+}


### PR DESCRIPTION
- Authenticate SDK via guest auth  (`/auth/guest/session` endpoint)
- Use GET `/live-streams/:id` when specifying specific a Livestream 
- Adds GET `/episodes/current` call that is used when no livestream id is specified.