### PR TITLE
Simplifying Player api

### DIFF
--- a/Example/LiveExampleAppUIKit/LiveExampleAppUIKit/ViewController.swift
+++ b/Example/LiveExampleAppUIKit/LiveExampleAppUIKit/ViewController.swift
@@ -135,15 +135,16 @@ class ViewController: UIViewController {
 	func buttonTapped() {
 		initializeSDK()
 
-		// 3) Create a LivePlayerViewController
+		// 3) Create a Player
 		var livePlayerVC: LivePlayerViewController
 		if let showId = showTextField.text, !showId.isEmpty {
-			livePlayerVC = LivePlayerViewController(showId: showId)
+			livePlayerVC = LiveSDK.player(showId: showId)
 		} else {
-			livePlayerVC = LivePlayerViewController() // Optionally pass in a LivestreamId to target a specific show.
+			livePlayerVC = LiveSDK.player()// Optionally pass in a LivestreamId to target a specific show.
 		}
 
 		livePlayerVC.delegate = self
+
 		present(livePlayerVC, animated: true, completion: nil)
 
 		saveOrgApiKeyForFutureLaunches()

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ You can find your `showId` in your web dashboard. Select the show you want and g
 
 This api exists with both **callbacks** and **Combine publishers** so your are free to choose the version that fits best with your app.
 
-## 4. Create a LivePlayerViewController
+## 4. Create a Player
 ```swift
-let livePlayerVC = LivePlayerViewController() // Optionally pass a showId.
+let livePlayerVC = LiveSDK.player() // Optionally pass a showId.
 livePlayerVC.delegate = self
 ```
 Without a `showId` parameter, the player will display the first live show it finds.

--- a/Sources/Live/LivePlayer/SDK/LiveSDK.swift
+++ b/Sources/Live/LivePlayer/SDK/LiveSDK.swift
@@ -19,6 +19,13 @@ public class LiveSDK {
 												 webSocketsUrl: "wss://\(environment.domain)/ws", apiKey: apiKey)
 	}
 
+	public static func player(showId: String? = nil) -> LivePlayerViewController {
+		if let showId = showId {
+			return LivePlayerViewController(showId: showId)
+		}
+		return LivePlayerViewController()
+	}
+
 	public static func isEpisodeLive() -> AnyPublisher<Bool, Error> {
 		return shared.api.authenticateAsGuest()
 			.flatMap { shared.api.getCurrentLiveStream() }


### PR DESCRIPTION
To create a player, users now call `LiveSDK.player()` instead of `LivePlayerViewController()`.
This is more in line with the rest of the public api using the `LiveSDK` prefix. 