### PR TITLE
Live in header

### DIFF
--- a/Sources/Live/LivePlayer/LivePlayer.swift
+++ b/Sources/Live/LivePlayer/LivePlayer.swift
@@ -97,7 +97,6 @@ public struct LivePlayer: View {
 	}
 	
 	let nextLiveStream: LiveStream?
-	let finishedPlaying: () -> Void
 	let close: (() -> Void)?
 	let proxy: GeometryProxy?
 	
@@ -110,7 +109,6 @@ public struct LivePlayer: View {
 	public init(
 		viewModel: LivePlayerViewModel,
 		nextLiveStream: LiveStream? = nil,
-		finishedPlaying: @escaping () -> Void,
 		close: (() -> Void)? = nil,
 		proxy: GeometryProxy? = nil,
 		isAllCaps: Bool,
@@ -125,12 +123,10 @@ public struct LivePlayer: View {
 		chatMessages: [ChatMessage],
 		fetchMessages: @escaping () -> Void,
 		sendMessage: @escaping (String, String?) -> Void,
-		
 		isInGuestMode: Bool
 	) {
 		self.viewModel = viewModel
 		self.nextLiveStream = nextLiveStream
-		self.finishedPlaying = finishedPlaying
 		self.close = close
 		self.proxy = proxy
 		
@@ -161,7 +157,7 @@ public struct LivePlayer: View {
 			switch liveStream.status {
 			case .idle, .waitingRoom:
 				if let previewVideoUrl = liveStream.previewVideoUrl {
-					VideoPlayer(url: previewVideoUrl, looping: true, isPlaying: true, isLive: true, isMuted: false, allowsPictureInPicture: false)
+					VideoPlayer(liveStream: liveStream, url: previewVideoUrl, looping: true, isPlaying: true, isLive: true, isMuted: false, allowsPictureInPicture: false)
 						.zIndex(2)
 				}
 			case .broadcasting:
@@ -173,7 +169,7 @@ public struct LivePlayer: View {
 							.foregroundColor(Color.white)
 					}
 					if let broadcastUrl = liveStream.broadcastUrl {
-						VideoPlayer(url: broadcastUrl, looping: false, isPlaying: isLivePlaying, isLive: true, isMuted: false, allowsPictureInPicture: true, finishedPlaying: finishedPlaying)
+						VideoPlayer(liveStream: liveStream, url: broadcastUrl, looping: false, isPlaying: isLivePlaying, isLive: true, isMuted: false, allowsPictureInPicture: true)
 					}
 				}.zIndex(2)
 			case .finished:

--- a/Sources/Live/LivePlayer/SDK/SDKPlayerView.swift
+++ b/Sources/Live/LivePlayer/SDK/SDKPlayerView.swift
@@ -30,7 +30,6 @@ struct SDKPlayerView: View {
 			GeometryReader { proxy in
 				LivePlayer(
 					viewModel: viewModel.livePlayerViewModel!,
-					finishedPlaying: { print("Finished playing") },
 					close: {
 						viewModel.didTapClose()
 					},

--- a/Sources/Live/LivePlayer/VideoPlayer.swift
+++ b/Sources/Live/LivePlayer/VideoPlayer.swift
@@ -29,33 +29,16 @@ public struct VideoPlayer: UIViewRepresentable {
 	public func makeUIView(context: Context) -> UIView {
 		let playerView = VideoAVPlayerView()
 		playerView.playerLayer?.videoGravity = .resizeAspectFill
-		if let assetURL = URL(string: url) {
-			let asset = AVAsset(url: assetURL)
-			let playerItem = AVPlayerItem(asset: asset)
-
-			if isLive {
-				playerItem.automaticallyPreservesTimeOffsetFromLive = true
-				playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = true
-			}
-
-			let player = AVQueuePlayer(playerItem: playerItem)
-			if looping {
-				context.coordinator.looper = AVPlayerLooper(player: player, templateItem: playerItem)
-			}
-			playerView.player = player
-			context.coordinator.player = player
-		}
+		context.coordinator.loadPlayer(url: url, in: playerView, isLooping: looping, isLive: isLive)
 		return playerView
 	}
 
 	public func updateUIView(_ uiView: UIView, context: Context) {
 		if isPlaying {
-
 			if isLive {
 				// Keep close to direct as much as possible.
 				context.coordinator.player?.seek(to: CMTime.positiveInfinity)
 			}
-
 			context.coordinator.player?.play()
 		} else {
 			context.coordinator.player?.pause()
@@ -67,9 +50,87 @@ public struct VideoPlayer: UIViewRepresentable {
 		return Coordinator()
 	}
 
-	public class Coordinator {
+	public class Coordinator: NSObject {
+
+		var url: String = ""
 		var looper: AVPlayerLooper?
 		var player: AVPlayer?
+		var playerView: VideoAVPlayerView?
+		var isLooping: Bool = false
+		var isLive: Bool = false
+		var playerItemContext = 0
+
+		func loadPlayer(url: String, in playerView: VideoAVPlayerView, isLooping: Bool, isLive: Bool) {
+			self.url = url
+			self.playerView = playerView
+			self.isLooping = isLooping
+			self.isLive = isLive
+			self.reloadPlayer()
+		}
+
+		func reloadPlayer() {
+			if let assetURL = URL(string: url) {
+				let asset = AVAsset(url: assetURL)
+				let playerItem = AVPlayerItem(asset: asset)
+
+				if isLive {
+					playerItem.automaticallyPreservesTimeOffsetFromLive = true
+					playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = true
+
+					// Register as an observer of the player item's status property
+					playerItem.addObserver(self,
+																		 forKeyPath: #keyPath(AVPlayerItem.status),
+																		 options: [.old, .new],
+																		 context: &playerItemContext)
+				}
+
+				if isLooping {
+					let queuePlayer = AVQueuePlayer(playerItem: playerItem)
+					looper = AVPlayerLooper(player: queuePlayer, templateItem: playerItem)
+					player = queuePlayer
+				} else {
+					player = AVPlayer(playerItem: playerItem)
+					player?.automaticallyWaitsToMinimizeStalling = true
+				}
+				playerView?.player = player
+			}
+		}
+
+		public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+
+			//Only handle observations for the playerItemContext
+			guard context == &playerItemContext else {
+				super.observeValue(forKeyPath: keyPath,
+													 of: object,
+													 change: change,
+													 context: context)
+				return
+			}
+
+			if keyPath == #keyPath(AVPlayerItem.status) {
+				let status: AVPlayerItem.Status
+
+				// Get the status change from the change dictionary
+				if let statusNumber = change?[.newKey] as? NSNumber {
+					status = AVPlayerItem.Status(rawValue: statusNumber.intValue)!
+				} else {
+					status = .unknown
+				}
+
+				// Switch over the status
+				switch status {
+				case .readyToPlay:
+					player?.play()
+				case .failed:
+					// Typical case is that Livestream just started and not ready to play yet.
+					// Retry 5s later.
+					Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { _ in
+						self.reloadPlayer()
+					}
+				case .unknown:()
+				}
+			}
+		}
 	}
 }
 

--- a/Sources/Live/LivePlayer/VideoPlayer.swift
+++ b/Sources/Live/LivePlayer/VideoPlayer.swift
@@ -15,12 +15,14 @@ public struct VideoPlayer: UIViewRepresentable {
 	let url: String
 	let looping: Bool
 	let isPlaying: Bool
+	let isLive: Bool
 	let isMuted: Bool
 
-	public init(url: String, looping: Bool, isPlaying: Bool, isMuted: Bool = false) {
+	public init(url: String, looping: Bool, isPlaying: Bool, isLive: Bool = true, isMuted: Bool = false) {
 		self.url = url
 		self.looping = looping
 		self.isPlaying = isPlaying
+		self.isLive = isLive
 		self.isMuted = isMuted
 	}
 
@@ -30,6 +32,12 @@ public struct VideoPlayer: UIViewRepresentable {
 		if let assetURL = URL(string: url) {
 			let asset = AVAsset(url: assetURL)
 			let playerItem = AVPlayerItem(asset: asset)
+
+			if isLive {
+				playerItem.automaticallyPreservesTimeOffsetFromLive = true
+				playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = true
+			}
+
 			let player = AVQueuePlayer(playerItem: playerItem)
 			if looping {
 				context.coordinator.looper = AVPlayerLooper(player: player, templateItem: playerItem)
@@ -42,6 +50,12 @@ public struct VideoPlayer: UIViewRepresentable {
 
 	public func updateUIView(_ uiView: UIView, context: Context) {
 		if isPlaying {
+
+			if isLive {
+				// Keep close to direct as much as possible.
+				context.coordinator.player?.seek(to: CMTime.positiveInfinity)
+			}
+
 			context.coordinator.player?.play()
 		} else {
 			context.coordinator.player?.pause()

--- a/Sources/Live/LivePlayer/VideoPlayer.swift
+++ b/Sources/Live/LivePlayer/VideoPlayer.swift
@@ -15,11 +15,13 @@ public struct VideoPlayer: UIViewRepresentable {
 	let url: String
 	let looping: Bool
 	let isPlaying: Bool
+	let isMuted: Bool
 
-	public init(url: String, looping: Bool, isPlaying: Bool) {
+	public init(url: String, looping: Bool, isPlaying: Bool, isMuted: Bool = false) {
 		self.url = url
 		self.looping = looping
 		self.isPlaying = isPlaying
+		self.isMuted = isMuted
 	}
 
 	public func makeUIView(context: Context) -> UIView {
@@ -44,6 +46,7 @@ public struct VideoPlayer: UIViewRepresentable {
 		} else {
 			context.coordinator.player?.pause()
 		}
+		context.coordinator.player?.isMuted = isMuted
 	}
 
 	public func makeCoordinator() -> VideoPlayer.Coordinator {


### PR DESCRIPTION
- Use same `VideoPlayer` for home and Liveplayer (removes `LivePlayerView`)
- Adds mute option
- Post playerDidFinishPlaying notification over callback
- Watch `playerItem` status & reload player every 5s if failed